### PR TITLE
Add Accept-Encoding header to axios requests

### DIFF
--- a/src/common/utils/image.ts
+++ b/src/common/utils/image.ts
@@ -7,6 +7,9 @@ import { logger } from '../logger';
 export async function downloadImageAsJson(url: string) {
   const { data } = await axios.get(url, {
     responseType: 'json',
+    headers: {
+      'Accept-Encoding': 'gzip, deflate',
+    },
   });
   return data;
 }
@@ -15,6 +18,9 @@ export async function downloadImageAsBase64(url: string) {
   try {
     const response = await axios.get(url, {
       responseType: 'arraybuffer',
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+      },
     });
 
     const imageBuffer = Buffer.from(response.data, 'binary');
@@ -31,6 +37,9 @@ export async function downloadFileAsBuffer(url: string) {
   try {
     const response = await axios.get(url, {
       responseType: 'arraybuffer',
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+      },
     });
 
     const imageBuffer = Buffer.from(response.data, 'binary');
@@ -45,6 +54,9 @@ export async function downloadFileTo(url: string, path: string) {
   try {
     const response = await axios.get(url, {
       responseType: 'arraybuffer',
+      headers: {
+        'Accept-Encoding': 'gzip, deflate',
+      },
     });
     const imageBuffer = Buffer.from(response.data, 'binary');
     fs.writeFileSync(path, imageBuffer);

--- a/src/modules/midjourney/midjourney.service.ts
+++ b/src/modules/midjourney/midjourney.service.ts
@@ -58,6 +58,11 @@ export class MidjourneyService {
           {
             task_id: task_id,
           },
+          {
+            headers: {
+              'Accept-Encoding': 'gzip, deflate',
+            },
+          },
         );
         const { status, task_result } = fetchData;
         this.pubMessage(
@@ -156,6 +161,7 @@ export class MidjourneyService {
         {
           headers: {
             'X-API-KEY': config.goapi.apikey,
+            'Accept-Encoding': 'gzip, deflate',
           },
         },
       );
@@ -192,6 +198,7 @@ export class MidjourneyService {
         {
           headers: {
             'X-API-KEY': config.goapi.apikey,
+            'Accept-Encoding': 'gzip, deflate',
           },
         },
       );


### PR DESCRIPTION
Add "Accept-Encoding": "gzip, deflate" header to axios requests.

* **src/common/utils/image.ts**
  - Add the "Accept-Encoding": "gzip, deflate" header to the axios request in the `downloadImageAsJson` function.
  - Add the "Accept-Encoding": "gzip, deflate" header to the axios request in the `downloadImageAsBase64` function.
  - Add the "Accept-Encoding": "gzip, deflate" header to the axios request in the `downloadFileAsBuffer` function.
  - Add the "Accept-Encoding": "gzip, deflate" header to the axios request in the `downloadFileTo` function.

* **src/modules/midjourney/midjourney.service.ts**
  - Add the "Accept-Encoding": "gzip, deflate" header to the axios request in the `pollResult` function.
  - Add the "Accept-Encoding": "gzip, deflate" header to the axios request in the `generateImageByGoApi` function.
  - Add the "Accept-Encoding": "gzip, deflate" header to the axios request in the `imageBlendByGoApi` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/inf-monkeys/monkey-tools-midjourney?shareId=a46f4588-b105-4afb-a28d-052e7e11cc87).